### PR TITLE
Skip logging in to ghcr.io in pull_requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
       -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
...since we don't need to actually push anything from pull requests.
Also because of this login step all current dependabot PRs fail (since
dependabot doesn't have access to repo secrets since this spring).

We could of course add separate secret for Dependabot if we want, but I
don't see the need right now:

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/managing-encrypted-secrets-for-dependabot
